### PR TITLE
Add movement macros

### DIFF
--- a/asm/macros/movement.inc
+++ b/asm/macros/movement.inc
@@ -126,6 +126,10 @@
 	create_movement_action figure_8
 	create_movement_action fly_up
 	create_movement_action fly_down
+	create_movement_action run_down_slow
+	create_movement_action run_up_slow
+	create_movement_action run_left_slow
+	create_movement_action run_right_slow
 
 	enum_start 0xfe
 	create_movement_action step_end


### PR DESCRIPTION
Adding them to movement macros should be the correct way to do this, even if you don't use them in any script, since it's needed if the user plans to add future movements (example: new emoticons or your expanded movement table).