### PR TITLE
Disable Rematches when FREE_MATCH_CALL is on.

### DIFF
--- a/src/battle_setup.c
+++ b/src/battle_setup.c
@@ -1132,6 +1132,7 @@ const u8 *BattleSetup_ConfigureTrainerBattle(const u8 *data)
         TrainerBattleLoadArgs(sContinueScriptDoubleBattleParams, data);
         SetMapVarsToTrainer();
         return EventScript_TryDoDoubleTrainerBattle;
+#ifndef FREE_MATCH_CALL
     case TRAINER_BATTLE_REMATCH_DOUBLE:
         TrainerBattleLoadArgs(sDoubleBattleParams, data);
         SetMapVarsToTrainer();
@@ -1142,6 +1143,7 @@ const u8 *BattleSetup_ConfigureTrainerBattle(const u8 *data)
         SetMapVarsToTrainer();
         gTrainerBattleOpponent_A = GetRematchTrainerId(gTrainerBattleOpponent_A);
         return EventScript_TryDoRematchBattle;
+#endif
     case TRAINER_BATTLE_PYRAMID:
         if (gApproachingTrainerId == 0)
         {


### PR DESCRIPTION
## Description
Disable Rematches when FREE_MATCH_CALL is on. Without this fix, the game assumes the trainer is ready for a rematch and talking to them instantly rematches them.

## **Discord contact info**
Greenphx#5428