### PR TITLE
Update pokenav_match_call_data.c

### DIFF
--- a/src/pokenav_match_call_data.c
+++ b/src/pokenav_match_call_data.c
@@ -1076,7 +1076,7 @@ static void MatchCall_GetNameAndDesc_Wally(match_call_t matchCall, const u8 **de
 static void MatchCall_GetNameAndDesc_Rival(match_call_t matchCall, const u8 **desc, const u8 **name)
 {
     *desc = matchCall.rival->desc;
-    *name = matchCall.rival->name;
+    *name = (gSaveBlock2Ptr->rivalName) ? gSaveBlock2Ptr->rivalName : matchCall.rival->name;
 }
 
 static void MatchCall_GetNameAndDesc_Birch(match_call_t matchCall, const u8 **desc, const u8 **name)


### PR DESCRIPTION
## Description
This makes the rival's name show up correctly inside the PokéNav's Match Call feature :eyes:

## **Discord contact info**
Lunos#4026