### PR TITLE
Changed the data type for the member sprite within the SubQuest and SideQuest structs from u8 to u16 to allow sprites with an index higher than 255 to be shown.

### DIFF
--- a/include/quests.h
+++ b/include/quests.h
@@ -14,7 +14,7 @@ struct SideQuest
 	/*0x08*/ const u8* poc;
 	/*0x0C*/ const u8* map;
 	///*0x10*/ const u8* hint;
-	/*0x14*/ const u8* reward;
+	/*0x14*/ const u16* reward;
 }; /* size = 0x18 */
 
 


### PR DESCRIPTION
## Description
[issac first discovered the issue](https://discord.com/channels/976252009114140682/976252039380209694/1041415021072228442) in the [Team Aqua Hideout discord](https://discord.gg/x8UJtnSX).

Without this fix, items like `ITEM_SAPPHIRE` won't work.

![image](https://user-images.githubusercontent.com/77138753/201543989-e3af2df8-6fd7-443c-b682-def3b339b1ca.png)
![image](https://user-images.githubusercontent.com/77138753/201544008-fe0800aa-4e18-4c3b-9408-3ee5e7fce1f0.png)
![image](https://user-images.githubusercontent.com/77138753/201544028-4705ead0-d88b-433d-816f-de6f4f3b4006.png)
![image](https://user-images.githubusercontent.com/77138753/201544041-3c04ab0b-55c9-4279-a344-990e10acc994.png)
![image](https://i.imgur.com/L3eh1ra.png)
![image](https://user-images.githubusercontent.com/77138753/201544081-b96fb811-4cba-4de0-a48c-c34380ef4df2.png)


## **Discord contact info**
psf#2936