### PR TITLE
Fixed map preview fade-in for weathers that set BLDALPHA.

### DIFF
--- a/src/field_weather.c
+++ b/src/field_weather.c
@@ -127,11 +127,11 @@ static const u8 sBasePaletteColorMapTypes[32] =
     COLOR_MAP_DARK_CONTRAST,
     COLOR_MAP_DARK_CONTRAST,
     COLOR_MAP_DARK_CONTRAST,
-    COLOR_MAP_DARK_CONTRAST,
-    COLOR_MAP_NONE,
-    COLOR_MAP_NONE,
+    COLOR_MAP_NONE, // shops; map previews
+    COLOR_MAP_NONE, // map popup
+    COLOR_MAP_NONE, // text boxes
     // sprite palettes
-    COLOR_MAP_CONTRAST,
+    COLOR_MAP_CONTRAST, // shadows; fog
     COLOR_MAP_DARK_CONTRAST,
     COLOR_MAP_CONTRAST,
     COLOR_MAP_CONTRAST,

--- a/src/map_preview.c
+++ b/src/map_preview.c
@@ -500,7 +500,7 @@ void MapPreview_StartForestTransition(u8 mapsec)
     taskId = CreateTask(Task_RunMapPreviewScreenForest, 0);
     gTasks[taskId].data[2] = GetBgAttribute(0, BG_ATTR_PRIORITY);
     gTasks[taskId].data[4] = GetGpuReg(REG_OFFSET_BLDCNT);
-    gTasks[taskId].data[5] = GetGpuReg(REG_OFFSET_BLDALPHA);
+    gTasks[taskId].data[5] = GetGpuReg(REG_OFFSET_BLDALPHA); // now unused
     gTasks[taskId].data[3] = GetGpuReg(REG_OFFSET_DISPCNT);
     gTasks[taskId].data[6] = GetGpuReg(REG_OFFSET_WININ);
     gTasks[taskId].data[7] = GetGpuReg(REG_OFFSET_WINOUT);
@@ -569,6 +569,7 @@ static void Task_RunMapPreviewScreenForest(u8 taskId)
         }
         break;
     case 2:
+        SetGpuReg(REG_OFFSET_BLDALPHA, BLDALPHA_BLEND(16, 0));
         if (IsWeatherNotFadingIn())
         {
             Overworld_PlaySpecialMapMusic();
@@ -576,6 +577,7 @@ static void Task_RunMapPreviewScreenForest(u8 taskId)
         }
         break;
     case 3:
+        SetGpuReg(REG_OFFSET_BLDALPHA, BLDALPHA_BLEND(16, 0));
         data[1]++;
         if (data[1] > data[10])
         {
@@ -617,7 +619,8 @@ static void Task_RunMapPreviewScreenForest(u8 taskId)
             SetBgAttribute(0, BG_ATTR_PRIORITY, data[2]);
             SetGpuReg(REG_OFFSET_DISPCNT, data[3]);
             SetGpuReg(REG_OFFSET_BLDCNT, data[4]);
-            SetGpuReg(REG_OFFSET_BLDALPHA, data[5]);
+            // Restore current weather's requested blend settings
+            SetGpuReg(REG_OFFSET_BLDALPHA, BLDALPHA_BLEND(gWeatherPtr->currBlendEVA, gWeatherPtr->currBlendEVB));
             SetGpuReg(REG_OFFSET_WININ, data[6]);
             SetGpuReg(REG_OFFSET_WINOUT, data[7]);
             DestroyTask(taskId);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fixes Shade weather being applied to the map preview for forest type transitions.
Fixes map preview interaction with weathers that initialize BLDALPHA.

## Description
If a weather sets blend parameters in its `InitVars` or `InitAll` functions, these interfere with the map preview's fade-in. Also, because the map preview grabs the state of BLDALPHA before this happens, it doesn't properly restore the blend settings for the weather afterwards.

This is only an issue for people using my lighting code or who have made other similar changes to weathers. However I can't really fix it on my end. So I just added a different way to reset the blend params after the fade-in, and made the task set them to 16, 0 until the fade-in starts, to fix these issues.

## **Discord contact info**
merrp#0001